### PR TITLE
Ability to set a shell script to run after sync is complete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ ENV VDIRSYNCER_CONFIG=/vdirsyncer/config \
         VDIRSYNCER_USER="vdirsyncer" \
         # Set cron file
         CRON_FILE="/etc/crontabs/vdirsyncer" \
+        # Script to run after sync complete
+        POST_SYNC_SCRIPT_FILE= \
         # Set Pipx home
         PIPX_HOME="/opt/pipx" \
         # Set Pipx bin dir

--- a/files/scripts/start.sh
+++ b/files/scripts/start.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# Post sync script
+if [ -z "${POST_SYNC_SCRIPT_FILE}" ]; then
+    POST_SYNC_SNIPPET=""
+else
+    POST_SYNC_SNIPPET=" && ${POST_SYNC_SCRIPT_FILE}"
+fi
+
 # Check if a logfile exists
 if [[ -e "${LOG}" ]]
 then
@@ -154,7 +162,7 @@ then
     # Write cronjob to file
     echo "${CRON_TIME} yes | /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} discover \
     && /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} metasync \
-    && /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} sync" >> "${CRON_FILE}"
+    && /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} sync ${POST_SYNC_SNIPPET}" >> "${CRON_FILE}"
 
     # User info
     echo 'Autodiscover and Autosync are enabled.' 2>&1 | ts '[%Y-%m-%d %H:%M:%S]' | tee -a "${LOG}"
@@ -176,7 +184,7 @@ elif [[ "${AUTODISCOVER}" == "false" ]] && [[ "${AUTOSYNC}" == "true" ]]
 then
     # Write cronjob to file
     echo "${CRON_TIME} /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} metasync \
-    && /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} sync" >> "${CRON_FILE}"
+    && /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} sync ${POST_SYNC_SNIPPET}" >> "${CRON_FILE}"
 
     # User info
     echo 'Only Autosync is enabled.' 2>&1 | ts '[%Y-%m-%d %H:%M:%S]' | tee -a "${LOG}"
@@ -197,7 +205,7 @@ then
 elif [[ "${AUTODISCOVER}" == "true" ]] && [[ "${AUTOSYNC}" == "false" ]]
 then
     # Write cronjob to file
-    echo "${CRON_TIME} yes | /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} discover" >> "${CRON_FILE}"
+    echo "${CRON_TIME} yes | /usr/local/bin/vdirsyncer -c ${VDIRSYNCER_CONFIG} discover ${POST_SYNC_SNIPPET}" >> "${CRON_FILE}"
 
     # User info
     echo 'Only Autodiscover is enabled.' 2>&1 | ts '[%Y-%m-%d %H:%M:%S]' | tee -a "${LOG}"


### PR DESCRIPTION
I need to run some logic after the sync completes and with the servers I'm syncing I was getting wildly different run times.

Using my own CRON_FILE didn't work because the startup script writes the schedule to it at startup, so I ended up with a duplicate every time the container restarted

This change simply lets you specify a script file in POST_SYNC_SCRIPT_FILE env var, and if set, will include it as part of the cron job command